### PR TITLE
Hide task action bars unless mousing over

### DIFF
--- a/app/javascript/controllers/task_preview_controller.js
+++ b/app/javascript/controllers/task_preview_controller.js
@@ -1,0 +1,14 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="task-preview"
+export default class extends Controller {
+  static targets = ["actionBar"]
+
+  mouseEnter() {
+    this.actionBarTarget.classList.toggle('hidden', false);
+  }
+
+  mouseLeave() {
+    this.actionBarTarget.classList.toggle('hidden', true);
+  }
+}

--- a/app/views/tasks/_list.html.erb
+++ b/app/views/tasks/_list.html.erb
@@ -6,7 +6,7 @@
           <section>
             <ul>
               <% incomplete_tasks_for_priority.each do |task| %>
-                <li class="mt-2 mb-6">
+                <li class="my-2">
                   <%= render 'tasks/preview', task: task %>
                 </li>
               <% end %>

--- a/app/views/tasks/_preview.html.erb
+++ b/app/views/tasks/_preview.html.erb
@@ -1,9 +1,11 @@
-<div>
-  <%= link_to task.name, task, class: "inline-block" %>
-</div>
-
-<%= turbo_frame_tag [dom_id(task), :action_bar] do %>
-  <div class="mt-2">
-    <%= render template: 'actions/index', locals: { task: task } %>
+<div data-controller="task-preview" data-action="mouseover->task-preview#mouseEnter mouseout->task-preview#mouseLeave">
+  <div>
+    <%= link_to task.name, task, class: "inline-block" %>
   </div>
-<% end %>
+
+  <%= turbo_frame_tag [dom_id(task), :action_bar] do %>
+    <div class="mt-2 hidden" data-task-preview-target="actionBar">
+      <%= render template: 'actions/index', locals: { task: task } %>
+    </div>
+  <% end %>
+</div>


### PR DESCRIPTION
All action bars on the page at the same time is too much noise, so only show action bars for tasks being moused over.