### PR TITLE
Add headers back, lists were too sparse

### DIFF
--- a/app/views/tasks/_list.html.erb
+++ b/app/views/tasks/_list.html.erb
@@ -4,6 +4,8 @@
       <% Task.priorities.keys.each do |priority_name| %>
         <% incomplete_tasks.send(:"prioritize_#{priority_name}").tap do |incomplete_tasks_for_priority| %>
           <section>
+            <h3 class="text-xl mt-8"><%= priority_name.humanize %></h3>
+
             <ul>
               <% incomplete_tasks_for_priority.each do |task| %>
                 <li class="my-2">
@@ -21,6 +23,8 @@
     <hr class="my-6">
 
     <div id="completed-tasks" class="min-w-full">
+      <h2 class="text-2xl mb-2">Completed tasks</h2>
+
       <ul>
         <% tasks.completed_status.each do |task| %>
           <li class="my-2">


### PR DESCRIPTION
Add priority/status headers back in to make the list easier to read.

<img width="1014" alt="image" src="https://github.com/user-attachments/assets/ebe8872b-ab71-4213-9de0-59b52aa6ea29" />
