### PR TITLE
Track task changes for an event log

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,0 +1,3 @@
+class Event < ApplicationRecord
+  belongs_to :eventable, polymorphic: true, optional: true
+end

--- a/db/migrate/20241221235610_create_events.rb
+++ b/db/migrate/20241221235610_create_events.rb
@@ -1,0 +1,10 @@
+class CreateEvents < ActiveRecord::Migration[8.0]
+  def change
+    create_table :events do |t|
+      t.text :description
+      t.references :eventable, polymorphic: true, null: false, foreign_key: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_12_13_180559) do
+ActiveRecord::Schema[8.0].define(version: 2024_12_21_235610) do
+  create_table "events", force: :cascade do |t|
+    t.text "description"
+    t.string "eventable_type", null: false
+    t.integer "eventable_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["eventable_type", "eventable_id"], name: "index_events_on_eventable"
+  end
+
   create_table "tasks", force: :cascade do |t|
     t.string "name"
     t.text "description"

--- a/test/fixtures/tasks.yml
+++ b/test/fixtures/tasks.yml
@@ -1,17 +1,19 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-one:
-  name: MyString
-  description: MyText
+new:
+  name: Do some things
+  description: In order to do some things, there are requirements!
   parent: one
-  status: MyString
+  status: new
   completed: false
   order: 1
+  priority: today
 
-two:
-  name: MyString
-  description: MyText
+completed:
+  name: Something previously completed
+  description: The requirements must have been met.
   parent: two
-  status: MyString
-  completed: false
+  status: completed
+  completed: true
   order: 2
+  priority: today

--- a/test/models/task_test.rb
+++ b/test/models/task_test.rb
@@ -1,7 +1,57 @@
 require "test_helper"
 
 class TaskTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  setup do
+    @task = tasks(:new)
+  end
+
+  test "changing name creates a new event" do
+    @task.update!(name: "starting name")
+
+    assert_difference -> { @task.events.count }, 1 do
+      @task.update!(name: "new name")
+    end
+
+    assert_includes @task.events.last.description, "starting name"
+    assert_includes @task.events.last.description, "new name"
+  end
+
+  test "changing description creates a new event" do
+    assert_difference -> { @task.events.count }, 1 do
+      @task.update!(description: "new description")
+    end
+  end
+
+  test "changing status creates a new event" do
+    @task.new_status!
+
+    assert_difference -> { @task.events.count }, 1 do
+      @task.completed_status!
+    end
+
+    assert_includes @task.events.last.description, "new"
+    assert_includes @task.events.last.description, "completed"
+  end
+
+  test "changing priority creates a new event" do
+    @task.prioritize_today!
+
+    assert_difference -> { @task.events.count }, 1 do
+      @task.prioritize_later!
+    end
+
+    assert_includes @task.events.last.description, "today"
+    assert_includes @task.events.last.description, "later"
+  end
+
+  test "changing tracking URL creates a new event" do
+    @task.update!(tracking_url: "starting URL")
+
+    assert_difference -> { @task.events.count }, 1 do
+      @task.update!(tracking_url: "new URL")
+    end
+
+    assert_includes @task.events.last.description, "starting URL"
+    assert_includes @task.events.last.description, "new URL"
+  end
 end


### PR DESCRIPTION
Start tracking changes so they can be displayed on a timeline. This will be useful both for seeing what I did yesterday (e.g. standup prep) and over long periods of time (e.g. impact review prep).