### PR TITLE
Remove task name from event descriptions

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -44,7 +44,7 @@ class Task < ApplicationRecord
   end
 
   def create_creation_events
-    events.create!(description: "[#{name}]: created")
+    events.create!(description: "task created")
   end
 
   def create_change_events
@@ -58,30 +58,30 @@ class Task < ApplicationRecord
   def create_name_change_event
     return unless name_changed?
 
-    events.create!(description: "[#{name_was}][name]: -> '#{name}'")
+    events.create!(description: "name: #{name_was} -> '#{name}'")
   end
 
   def create_description_change_event
     return unless description_changed?
 
-    events.create!(description: "[#{name}][description]: changed")
+    events.create!(description: "description changed")
   end
 
   def create_status_change_event
     return unless status_changed?
 
-    events.create!(description: "[#{name}][status]: #{status_was} -> #{status}")
+    events.create!(description: "status: #{status_was} -> #{status}")
   end
 
   def create_priority_change_event
     return unless priority_changed?
 
-    events.create!(description: "[#{name}][priority]: #{priority_was} -> #{priority}")
+    events.create!(description: "priority: #{priority_was} -> #{priority}")
   end
 
   def create_tracking_url_change_event
     return unless tracking_url_changed?
 
-    events.create!(description: "[#{name}][tracking_url]: #{tracking_url_was} -> #{tracking_url}")
+    events.create!(description: "tracking_url: #{tracking_url_was} -> #{tracking_url}")
   end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -13,6 +13,7 @@ class Task < ApplicationRecord
 
   after_create :create_creation_events
   before_update :create_change_events
+  after_destroy :clarify_orphaned_events
 
   enum :status, {
     new: "new",
@@ -83,5 +84,11 @@ class Task < ApplicationRecord
     return unless tracking_url_changed?
 
     events.create!(description: "tracking_url: #{tracking_url_was} -> #{tracking_url}")
+  end
+
+  def clarify_orphaned_events
+    events.each do |event|
+      event.update_column(:description, "[#{name}] #{event.description}")
+    end
   end
 end

--- a/app/models/timeline.rb
+++ b/app/models/timeline.rb
@@ -1,4 +1,6 @@
 class Timeline
+  ORPHANED_EVENTS_GROUP_NAME = "Events for deleted items"
+
   def events
     Event.all.order(created_at: :desc)
   end

--- a/app/views/timelines/_events_by_date.html.erb
+++ b/app/views/timelines/_events_by_date.html.erb
@@ -1,0 +1,9 @@
+<% date_groups.each do |date, events|%>
+  <section>
+    <h2 class="block text-xl text-slate-300">
+      <%= date.strftime("%a, %b %d, %Y") %>
+    </h2>
+
+    <%= render 'events_by_eventable', events: events %>
+  </section>
+<% end %>

--- a/app/views/timelines/_events_by_eventable.html.erb
+++ b/app/views/timelines/_events_by_eventable.html.erb
@@ -1,0 +1,11 @@
+<ul class="flex flex-col gap-4">
+  <% events.group_by(&:eventable).each do |eventable, events| %>
+    <li>
+      <h3 class="block text-lg text-slate-500">
+        <%= eventable&.name || Timeline::ORPHANED_EVENTS_GROUP_NAME %>
+      </h3>
+
+      <%= render 'plain_event_list', events: events %>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/timelines/_plain_event_list.html.erb
+++ b/app/views/timelines/_plain_event_list.html.erb
@@ -1,0 +1,7 @@
+<ul class="text-slate-800">
+  <% events.each do |event| %>
+    <li>
+      <%= event.description %>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/timelines/show.html.erb
+++ b/app/views/timelines/show.html.erb
@@ -10,30 +10,6 @@
   <h1 class="font-bold text-4xl mb-4">Timeline</h1>
 
   <div class="flex flex-col gap-10">
-    <% @timeline.events_grouped_by_date.each do |date, events|%>
-      <section>
-        <h2 class="block text-xl text-slate-500">
-          <%= date.strftime("%a, %b %d, %Y") %>
-        </h2>
-
-        <ul class="flex flex-col gap-4">
-          <% events.group_by(&:eventable).each do |eventable, events| %>
-            <li>
-              <h3 class="block text-lg text-slate-500">
-                <%= eventable.name %>
-              </h3>
-
-              <ul class="text-slate-800">
-                <% events.each do |event| %>
-                  <li>
-                    <%= event.description %>
-                  </li>
-                <% end %>
-              </ul>
-            </li>
-          <% end %>
-        </ul>
-      </section>
-    <% end %>
+    <%= render 'events_by_date', date_groups: @timeline.events_grouped_by_date %>
   </div>
 </div>

--- a/app/views/timelines/show.html.erb
+++ b/app/views/timelines/show.html.erb
@@ -16,10 +16,20 @@
           <%= date.strftime("%a, %b %d, %Y") %>
         </h2>
 
-        <ul class="text-slate-800">
-          <% events.each do |event| %>
+        <ul class="flex flex-col gap-4">
+          <% events.group_by(&:eventable).each do |eventable, events| %>
             <li>
-              <%= event.description %>
+              <h3 class="block text-lg text-slate-500">
+                <%= eventable.name %>
+              </h3>
+
+              <ul class="text-slate-800">
+                <% events.each do |event| %>
+                  <li>
+                    <%= event.description %>
+                  </li>
+                <% end %>
+              </ul>
             </li>
           <% end %>
         </ul>

--- a/test/models/task_test.rb
+++ b/test/models/task_test.rb
@@ -61,7 +61,5 @@ class TaskTest < ActiveSupport::TestCase
     assert_difference -> { Event.count }, 1 do
       task = Task.create!(name: "the new task")
     end
-
-    assert_includes task.events.last.description, "the new task"
   end
 end

--- a/test/models/task_test.rb
+++ b/test/models/task_test.rb
@@ -62,4 +62,14 @@ class TaskTest < ActiveSupport::TestCase
       task = Task.create!(name: "the new task")
     end
   end
+
+  test "destroying prepends task name to all orphaned events" do
+    task = Task.create!(name: "the new task")
+    event = task.events.first
+
+    refute_includes event.description, task.name
+
+    task.destroy
+    assert_includes event.reload.description, task.name
+  end
 end


### PR DESCRIPTION
- Removes `[task name]` that was previously prepended to every event description
- Groups events by date and eventable for nicer viewing